### PR TITLE
Allow executing sub-tasks based on variable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -189,3 +189,7 @@ cvmfs_upgrade_server: false
 # Install a setuid binary allowing unprivileged users to call `cvmfs_config wipecache` or `cvmfs_talk remount sync`?
 cvmfs_install_setuid_cvmfs_wipecache: no
 cvmfs_install_setuid_cvmfs_remount_sync: no
+
+# You can manually specify a role if you don't want to or cannot use the
+# group_names
+# cvmfs_role: 'client' # (Or stratum1 or stratum0 or localproxy)

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -62,13 +62,13 @@
   when: ansible_os_family == "RedHat"
 
 - include: client.yml
-  when: "'cvmfsclients' in group_names"
+  when: "'cvmfsclients' in group_names or cvmfs_role == 'client'"
 
 - include: stratum1.yml
-  when: "'cvmfsstratum1servers' in group_names"
+  when: "'cvmfsstratum1servers' in group_names or cvmfs_role == 'stratum1'"
 
 - include: stratum0.yml
-  when: "'cvmfsstratum0servers' in group_names"
+  when: "'cvmfsstratum0servers' in group_names or cvmfs_role == 'stratum0'"
 
 - include: localproxy.yml
-  when: "'cvmfslocalproxies' in group_names"
+  when: "'cvmfslocalproxies' in group_names or cvmfs_role == 'localproxy'"


### PR DESCRIPTION
Instead of requiring the use of the group_name (inconvenient for us in building VM images.)