### PR TITLE
Fix role failing on Squid task "Create the cache directories for the first time"

### DIFF
--- a/tasks/squid.yml
+++ b/tasks/squid.yml
@@ -6,7 +6,7 @@
     backup: true
     mode: 0644
   notify:
-    - restart squid
+    - Restart squid
 
 - name: Fix cache directory permission
   ansible.builtin.file:
@@ -18,13 +18,27 @@
     setype: squid_cache_t
   when: cvmfs_stratum1_cache_dir is defined
 
-- name: Create the cache directories for the first time
-  become: true
-  become_user: "{{ cvmfs_squid_user }}"
-  ansible.builtin.command: squid -z
-  args:
-    creates: "{{ cvmfs_stratum1_cache_dir }}/00"
+- name: Check whether the cache directories exist
+  ansible.builtin.stat:
+    path: "{{ cvmfs_stratum1_cache_dir.dir }}/00"
+  register: cvmfs_stratum1_cache_dir_stat
   when: cvmfs_stratum1_cache_dir is defined
+
+- name: Create the cache directories for the first time
+  when: cvmfs_stratum1_cache_dir is defined and not cvmfs_stratum1_cache_dir_stat.stat.exists
+  block:
+
+  - name: Ensure squid is stopped
+    ansible.builtin.service:
+      name: "{{ cvmfs_squid_service_name }}"
+      state: stopped
+
+  - name: Create the cache directories
+    become: true
+    become_user: "{{ cvmfs_squid_user }}"
+    ansible.builtin.command: squid -z
+    args:
+      creates: "{{ cvmfs_stratum1_cache_dir.dir }}/00"
 
 - name: Ensure squid is enabled and started
   ansible.builtin.service:


### PR DESCRIPTION
Squid cannot be launched if it is already running. If the role has been run at least once, then Squid will fail to execute during the "Create the cache directories for the first time" task, causing the whole role to fail.

This PR changes the behavior of the role so that it tries to create the cache directories only if they do not exist. In addition, it ensures Squid is not running before trying to do so.